### PR TITLE
Fix bug with QuadPoints transforms

### DIFF
--- a/src/main/java/com/itextpdf/forms/xfdf/XfdfObjectReadingUtils.java
+++ b/src/main/java/com/itextpdf/forms/xfdf/XfdfObjectReadingUtils.java
@@ -102,7 +102,7 @@ public final class XfdfObjectReadingUtils {
         }
         float[] transfQuadPoints = new float[sz];
         transf.transform(quadPoints, 0, transfQuadPoints, 0, sz / 2);
-        return quadPoints;
+        return transfQuadPoints;
     }
 
     /**


### PR DESCRIPTION
In all annotations with QuadPoints, the annotation processing logic accidentally used the untransformed value of QuadPoints instead of the transformed one.